### PR TITLE
Improved reporter; changed style, outputs expected indentation level.

### DIFF
--- a/tasks/constants/messages.js
+++ b/tasks/constants/messages.js
@@ -1,8 +1,8 @@
 module.exports = {
-	INDENTATION_TABS: 'no correct indentation with tabs.',
-	INDENTATION_SPACES: 'no correct indentation with spaces.',
-	INDENTATION_SPACES_AMOUNT: 'incorrect amout of spaces as indentation.',
-	TRAILINGSPACES: 'trailing spaces found.',
-	NEWLINE: 'no newline at end of file.',
-	NEWLINE_AMOUNT: 'too many new lines at end of file.'
+	INDENTATION_TABS          : 'Unexpected spaces found.',
+	INDENTATION_SPACES        : 'Unexpected tabs found.',
+	INDENTATION_SPACES_AMOUNT : 'Expected an indentation at {a} instead of at {b}.',
+	TRAILINGSPACES            : 'Unexpected trailing spaces found.',
+	NEWLINE                   : 'Expected a newline at the end of the file.',
+	NEWLINE_AMOUNT            : 'Unexpected additional newlines at the end of the file.'
 };

--- a/tasks/lintspaces.js
+++ b/tasks/lintspaces.js
@@ -76,8 +76,18 @@ module.exports = function(grunt) {
 					} else {
 						// indentation correct, is amount of spaces correct?
 						if(typeof options.spaces === 'number') {
-							if(line.match(spacesLeadingRegExp)[1].length % options.spaces !== 0) {
-								return formatMessage(index + 1, MESSAGES.INDENTATION_SPACES_AMOUNT);
+							var indent = line.match(spacesLeadingRegExp)[1].length;
+							if(indent % options.spaces !== 0) {
+								var
+									makeMultiple = function(input) {
+										// Round up or down the input based on the spaces that we configured
+										return Math.round(input/options.spaces) * options.spaces;
+									},
+									message = MESSAGES.INDENTATION_SPACES_AMOUNT
+										.replace('{a}', makeMultiple(indent))
+										.replace('{b}', indent)
+								;
+								return formatMessage(index + 1, message);
 							}
 						}
 					}
@@ -195,7 +205,7 @@ module.exports = function(grunt) {
 	/* Formating output.
 	/* ---------------------------------------------------------------------- */
 	function formatMessage(linenumber, message) {
-		return 'L'+ linenumber +': '+ message;
+		return 'L'+ linenumber +': '+ message.yellow;
 	}
 
 	function pushWarning(warnings, warning) {
@@ -210,10 +220,11 @@ module.exports = function(grunt) {
 		;
 
 		if(warnings.length > 0) {
-			msg = '\nErrors found at '+ path;
+			msg = 'ERROR: '.red + path.underline;
 			warnings.forEach(function(warning) {
-				msg += '\n\t'+ warning;
+				msg += '\n'+ warning;
 			});
+			msg += '\n';
 		}
 
 		return msg;
@@ -223,7 +234,8 @@ module.exports = function(grunt) {
 		var fileInfo = amount +' file'+ ((amount > 1) ? 's' : '') +' checked.';
 
 		if(output.length > 0) {
-			grunt.fail.warn(output +'\n')+ fileInfo +'\n';
+			grunt.log.writeln(output);
+			grunt.fail.warn('Formatting check failed.');
 		} else {
 			grunt.log.ok('All spaces are correct.\n'+ fileInfo +'\n');
 		}


### PR DESCRIPTION
I'd like to start changing the reporter of lintspaces to be more like JSHint's, in that it shows you a line number, column and a preview of the code that failed the lint check. This PR is a step towards that; I wanted to clarify the messaging from the task so I rewrote those, and changed the reporter slightly so that it doesn't output all in yellow.

![screen shot 2013-11-06 at 21 58 49](https://f.cloud.github.com/assets/1282980/1487444/2088f038-4734-11e3-8505-b6ba334f723a.png)

For JSHint 3, code style checks will be dropped from the codebase, so it would be good if we can make the reporter for lintspaces more robust in order to fill the gap.
