### PR TITLE
Moved lint success/pass to messages constant, simplified the success message.

### DIFF
--- a/tasks/constants/messages.js
+++ b/tasks/constants/messages.js
@@ -1,4 +1,6 @@
 module.exports = {
+	PASSED_LINTING: '{a} lint free.',
+	FAILED_LINTING: 'Formatting check failed.',
 	INDENTATION_TABS: 'Unexpected spaces found.',
 	INDENTATION_SPACES: 'Unexpected tabs found.',
 	INDENTATION_SPACES_AMOUNT: 'Expected an indentation at {a} instead of at {b}.',

--- a/tasks/lintspaces.js
+++ b/tasks/lintspaces.js
@@ -230,13 +230,13 @@ module.exports = function(grunt) {
 	}
 
 	function printOutput(output, amount) {
-		var fileInfo = amount +' file'+ ((amount > 1) ? 's' : '') +' checked.';
+		var fileInfo = amount +' file'+ ((amount > 1) ? 's' : '');
 
 		if(output.length > 0) {
 			grunt.log.writeln(output);
-			grunt.fail.warn('Formatting check failed.');
+			grunt.fail.warn(MESSAGES.FAILED_LINTING);
 		} else {
-			grunt.log.ok('All spaces are correct.\n'+ fileInfo +'\n');
+			grunt.log.ok(MESSAGES.PASSED_LINTING.replace('{a}', fileInfo));
 		}
 	}
 };

--- a/tests/test_comments.js
+++ b/tests/test_comments.js
@@ -1,4 +1,5 @@
 var
+	MESSAGES = require('./../tasks/constants/messages'),
 	path = require('path'),
 	exec = require('child_process').exec,
 	execOptions = {
@@ -94,7 +95,7 @@ exports.tests = {
 	nomatches: function(test) {
 		test.expect(1);
 		exec('grunt lintspaces:comments_nomatches', execOptions, function(error, stdout) {
-			test.equal(stdout.indexOf('All spaces are correct.') > -1, true,
+			test.equal(stdout.indexOf(MESSAGES.PASSED_LINTING.replace('{a}', '')) > -1, true,
 				'There is an error'
 			);
 

--- a/tests/test_directory.js
+++ b/tests/test_directory.js
@@ -1,4 +1,5 @@
 var
+	MESSAGES = require('./../tasks/constants/messages'),
 	path = require('path'),
 	exec = require('child_process').exec,
 	execOptions = {
@@ -11,7 +12,7 @@ exports.tests = {
 		test.expect(1);
 		exec('grunt lintspaces:directory', execOptions, function(error, stdout) {
 			test.equal(
-				stdout.indexOf('All spaces are correct.') > -1,
+				stdout.indexOf(MESSAGES.PASSED_LINTING.replace('{a}', '')) > -1,
 				true,
 				'This is a directory.'
 			);

--- a/tests/test_newlines.js
+++ b/tests/test_newlines.js
@@ -1,4 +1,5 @@
 var
+	MESSAGES = require('./../tasks/constants/messages'),
 	path = require('path'),
 	exec = require('child_process').exec,
 	execOptions = {
@@ -11,7 +12,7 @@ exports.tests = {
 		test.expect(1);
 		exec('grunt lintspaces:newline_okay', execOptions, function(error, stdout) {
 			test.equal(
-				stdout.indexOf('All spaces are correct.') > -1,
+				stdout.indexOf(MESSAGES.PASSED_LINTING.replace('{a}', '')) > -1,
 				true,
 				'newlines are fine.'
 			);


### PR DESCRIPTION
Could have done this in the last patch, however I think it's best to not modify too many things at once making PRs easier to deal with. Anyway, I changed this because I thought it was a little verbose:

```
>> All spaces are correct.
>> 5 files checked.

becomes:

>> 5 files lint free.
```

Also, moved the pass/fail messages to the array so they are easier to test.
