### PR TITLE
Extending comments unit test with two comment blocks that makes 'ignores...

### DIFF
--- a/tests/files/comments/comments.js
+++ b/tests/files/comments/comments.js
@@ -2,48 +2,68 @@
  * This is a multiline comment.
  */
 (function() {
-	var
-		foo = 'baz',
-		bar
-	;
+    var
+        foo = 'baz',
+        bar
+        ;
 
-	/*
-	 * This is a multiline comment with a python multiline comment inside:
-	 * '''
-	 *	This is a python multiline
-	 *	comment.
-	 *	'''
-	 */
+    /*
+     * This is a multiline comment with a python multiline comment inside:
+     * '''
+     *	This is a python multiline
+     *	comment.
+     *	'''
+     */
 
-	// Crazy python comments '''
+    // Crazy python comments '''
 
-	/* This is a multiline comment in a single line. */
-	function test() { /* This is a multiline comment at the end of a line. */
-		window.alert(foo);
-		window.alert(bar);
-	}
+    /* This is a multiline comment in a single line. */
+    function test() { /* This is a multiline comment at the end of a line. */
+        window.alert(foo);
+        window.alert(bar);
+    }
 
-	/* This is a multiline comment at the beginning of a line. */ test();
+    /* This is a multiline comment at the beginning of a line. */ test();
 
-	foo = 'omg';/*
-	 * This is a really strange multiline comment but valid (more or less)
-	 */bar = 'wtf';
+    foo = 'omg';/*
+     * This is a really strange multiline comment but valid (more or less)
+     */bar = 'wtf';
 
-	 /*
-	 * This one should match as ignore expect the first line.
-	 *
-	 *
-	 *
-	 *
-	 *
-	 */
+    /*
+     * This one should match as ignore expect the first line.
+     *
+     *
+     *
+     *
+     *
+     */
 
-	/* This is an other format
-	/*
-	/*
-	/* And should match as ignore */
+    /* This is an other format
+     /*
+     /*
+     /* And should match as ignore */
 
-	 /* And this too. */
+    /* And this too. */
 
-	 test(); /* Aaaaand this too. */
+    test(); /* Aaaaand this too. */
+
+    bar = {
+
+        bar: {
+
+            /**
+             * handles a static list filter (type == static) based on the defined mode
+             * @private
+             * @param    {jQuery.Event} event
+             */
+            a1: 1
+
+            /**
+             * handles a static list filter (type == static) based on the defined mode
+             * @private
+             * @param    {jQuery.Event} event
+             */
+        }
+    };
+
 })();

--- a/tests/test_comments.js
+++ b/tests/test_comments.js
@@ -1,105 +1,107 @@
 var
-	MESSAGES = require('./../tasks/constants/messages'),
-	path = require('path'),
-	exec = require('child_process').exec,
-	execOptions = {
-		cwd: path.join(__dirname, '..')
-	}
-;
+    MESSAGES = require('./../tasks/constants/messages'),
+    path = require('path'),
+    exec = require('child_process').exec,
+    execOptions = {
+        cwd: path.join(__dirname, '..')
+    }
+    ;
 
 function run(test, cmd, ignores, finds) {
-	test.expect(ignores.length + finds.length);
-	exec(cmd, execOptions, function(error, stdout) {
-		ignores.forEach(function(line) {
-			test.equal(stdout.indexOf('L'+ line +':') > -1, false,
-				'this is a comment and should be ignored (L'+ line +')'
-			);
-		});
+    test.expect(ignores.length + finds.length);
+    exec(cmd, execOptions, function(error, stdout) {
+        ignores.forEach(function(line) {
+            test.equal(stdout.indexOf('L'+ line +':') > -1, false,
+                'this is a comment and should be ignored (L'+ line +')'
+            );
+        });
 
-		finds.forEach(function(line) {
-			test.equal(stdout.indexOf('L'+ line +':') > -1, true,
-				'this is not a comment (L'+ line +')'
-			);
-		});
+        finds.forEach(function(line) {
+            test.equal(stdout.indexOf('L'+ line +':') > -1, true,
+                'this is not a comment (L'+ line +')'
+            );
+        });
 
-		test.done();
-	});
+        test.done();
+    });
 }
 
 exports.tests = {
-	pattern: function(test) {
-		var
-			linesToIgnore = [
-				2, 3,
-				11, 12, 13, 14, 15, 16,
-				29, 30, 33, 34, 35, 36, 37, 38, 39,
-				42, 43, 44
-			],
-			linesToFind = [
-				32,
-				46,
-				48
-			]
-		;
+    pattern: function(test) {
+        var
+            linesToIgnore = [
+                2, 3,
+                11, 12, 13, 14, 15, 16,
+                29, 30, 33, 34, 35, 36, 37, 38, 39,
+                42, 43, 44
+            ],
+            linesToFind = [
+                32,
+                46,
+                48
+            ]
+            ;
 
-		run(test, 'grunt lintspaces:comments_pattern', linesToIgnore, linesToFind);
-	},
+        run(test, 'grunt lintspaces:comments_pattern', linesToIgnore, linesToFind);
+    },
 
-	buildinJs: function(test) {
-		var
-			linesToIgnore = [
-				2, 3,
-				11, 12, 13, 14, 15, 16,
-				29, 30, 33, 34, 35, 36, 37, 38, 39,
-				42, 43, 44
-			],
-			linesToFind = [
-				32,
-				46,
-				48
-			]
-		;
+    buildinJs: function(test) {
+        var
+            linesToIgnore = [
+                2, 3,
+                11, 12, 13, 14, 15, 16,
+                29, 30, 33, 34, 35, 36, 37, 38, 39,
+                42, 43, 44,
+                55, 56, 57, 58,
+                62, 63, 64, 65
+            ],
+            linesToFind = [
+                32,
+                46,
+                48
+            ]
+            ;
 
-		run(test, 'grunt lintspaces:comments_buildin_js', linesToIgnore, linesToFind);
-	},
+        run(test, 'grunt lintspaces:comments_buildin_js', linesToIgnore, linesToFind);
+    },
 
-	buildinPy: function(test) {
-		var
-			linesToIgnore = [
-				2, 3, 4,
-				7, 8, 9
-			],
-			linesToFind = [
-				12
-			]
-		;
+    buildinPy: function(test) {
+        var
+            linesToIgnore = [
+                2, 3, 4,
+                7, 8, 9
+            ],
+            linesToFind = [
+                12
+            ]
+            ;
 
-		run(test, 'grunt lintspaces:comments_buildin_py', linesToIgnore, linesToFind);
-	},
+        run(test, 'grunt lintspaces:comments_buildin_py', linesToIgnore, linesToFind);
+    },
 
-	buildinXml: function(test) {
-		var
-			linesToIgnore = [
-				4, 5, 6, 7,
-				9, 10, 11
-			],
-			linesToFind = [
-				14,
-				16
-			]
-		;
+    buildinXml: function(test) {
+        var
+            linesToIgnore = [
+                4, 5, 6, 7,
+                9, 10, 11
+            ],
+            linesToFind = [
+                14,
+                16
+            ]
+            ;
 
-		run(test, 'grunt lintspaces:comments_buildin_xml', linesToIgnore, linesToFind);
-	},
+        run(test, 'grunt lintspaces:comments_buildin_xml', linesToIgnore, linesToFind);
+    },
 
-	nomatches: function(test) {
-		test.expect(1);
-		exec('grunt lintspaces:comments_nomatches', execOptions, function(error, stdout) {
-			test.equal(stdout.indexOf(MESSAGES.PASSED_LINTING.replace('{a}', '')) > -1, true,
-				'There is an error'
-			);
+    nomatches: function(test) {
+        test.expect(1);
+        exec('grunt lintspaces:comments_nomatches', execOptions, function(error, stdout) {
+            test.equal(stdout.indexOf(MESSAGES.PASSED_LINTING.replace('{a}', '')) > -1, true,
+                'There is an error'
+            );
 
-			test.done();
-		});
-	}
+            test.done();
+        });
+    }
 };


### PR DESCRIPTION
Extending comments unit test with two comment blocks that makes 'ignores: ['js_comments']' fail unexpectedly. Insert a blank space between "@param" and "{jQuery..." at line #57 of comments.js restores the expected behavior.
